### PR TITLE
Update ESP32_Web_Radio_AP.ino  Issue #4

### DIFF
--- a/ESP32_Web_Radio_AP.ino
+++ b/ESP32_Web_Radio_AP.ino
@@ -89,7 +89,7 @@ void setup () {
   pinMode(rotaryDT, INPUT);
   pinMode(rotaryCLK, INPUT);
 
-  ESP32Encoder::useInternalWeakPullResistors = UP;
+  ESP32Encoder::useInternalWeakPullResistors = puType::up;
   encoder.attachHalfQuad(rotaryDT, rotaryCLK);
   pinMode(rotarySW, INPUT_PULLUP);
 


### PR DESCRIPTION
line 92 changed from "UP" to "puType::up"

If using versions of the madhephaestus encoder V0.10.2 and older, UP works.
If using version V0.11.0 and newer then puType::up is needed.